### PR TITLE
Use hash for endpoint worker map

### DIFF
--- a/pkg/aerospike/endpoint.go
+++ b/pkg/aerospike/endpoint.go
@@ -28,6 +28,7 @@ type AerospikeEndpoint struct {
 }
 
 func (e *AerospikeEndpoint) GetHash() string {
+	hash := fmt.Sprintf("%s/%s", e.ClusterName, e.Name)
 	// If Namespaces are pushed through service discovery
 	// the hash should change according to the Namespaces
 	if !e.AutoDiscoverNamespaces {
@@ -37,9 +38,9 @@ func (e *AerospikeEndpoint) GetHash() string {
 			namespaces = append(namespaces, str)
 		}
 		sort.Strings(namespaces)
-		return fmt.Sprintf("%s/ns:%s", e.Name, namespaces)
+		return fmt.Sprintf("%s/ns:%s", hash, namespaces)
 	}
-	return e.Name
+	return hash
 }
 
 func (e *AerospikeEndpoint) GetName() string {

--- a/pkg/aerospike/endpoint_test.go
+++ b/pkg/aerospike/endpoint_test.go
@@ -11,16 +11,16 @@ func TestHashWorks(t *testing.T) {
 		"00":  {},
 	}
 
-	e := AerospikeEndpoint{Name: name, AutoDiscoverNamespaces: true}
-	if e.GetHash() != "foobar" {
+	e := AerospikeEndpoint{Name: name, ClusterName: "foo", AutoDiscoverNamespaces: true}
+	if e.GetHash() != "foo/foobar" {
 		t.Errorf("Hash failed: expected: %s, got: %s", name, e.GetHash())
 	}
-	e = AerospikeEndpoint{Name: name, AutoDiscoverNamespaces: false}
-	if e.GetHash() != "foobar/ns:[]" {
+	e = AerospikeEndpoint{Name: name, ClusterName: "foo", AutoDiscoverNamespaces: false}
+	if e.GetHash() != "foo/foobar/ns:[]" {
 		t.Errorf("Hash failed: expected: %s, got: %s", "foobar/ns:[]", e.GetHash())
 	}
-	e = AerospikeEndpoint{Name: name, AutoDiscoverNamespaces: false, Namespaces: ns}
-	if e.GetHash() != "foobar/ns:[00 bar fo ob]" {
+	e = AerospikeEndpoint{Name: name, ClusterName: "foo", AutoDiscoverNamespaces: false, Namespaces: ns}
+	if e.GetHash() != "foo/foobar/ns:[00 bar fo ob]" {
 		t.Errorf("Hash failed: expected: %s, got: %s (order is important)", "foobar/ns:[00 bar fo ob]", e.GetHash())
 	}
 }


### PR DESCRIPTION
Also made the termination of endpoint workers async.
Before the map was using the object itself. It is not reliable so it is replaced by the hash directly