### PR TITLE
Remove namespace auto-discover feature

### DIFF
--- a/pkg/aerospike/discovery.go
+++ b/pkg/aerospike/discovery.go
@@ -48,7 +48,6 @@ func (conf *AerospikeProbeConfig) generateAerospikeEndpointFromEntry(logger log.
 	}
 
 	namespaces := make(map[string]struct{})
-	autoDiscoverNamespaces := true
 
 	if conf.AerospikeEndpointConfig.NamespaceMetaKey != "" {
 		nsString, ok := entry.Meta[conf.AerospikeEndpointConfig.NamespaceMetaKey]
@@ -57,14 +56,12 @@ func (conf *AerospikeProbeConfig) generateAerospikeEndpointFromEntry(logger log.
 			for _, ns := range nsFromDiscovery {
 				namespaces[ns] = struct{}{}
 			}
-			autoDiscoverNamespaces = false
 		}
 	}
 
 	return &AerospikeEndpoint{Name: entry.Address,
-		ClusterName:            clusterName,
-		Namespaces:             namespaces,
-		AutoDiscoverNamespaces: autoDiscoverNamespaces,
+		ClusterName: clusterName,
+		Namespaces:  namespaces,
 		Config: AerospikeClientConfig{
 			// auth
 			authEnabled: authEnabled,

--- a/pkg/aerospike/endpoint_test.go
+++ b/pkg/aerospike/endpoint_test.go
@@ -11,15 +11,11 @@ func TestHashWorks(t *testing.T) {
 		"00":  {},
 	}
 
-	e := AerospikeEndpoint{Name: name, ClusterName: "foo", AutoDiscoverNamespaces: true}
-	if e.GetHash() != "foo/foobar" {
-		t.Errorf("Hash failed: expected: %s, got: %s", name, e.GetHash())
-	}
-	e = AerospikeEndpoint{Name: name, ClusterName: "foo", AutoDiscoverNamespaces: false}
+	e := AerospikeEndpoint{Name: name, ClusterName: "foo"}
 	if e.GetHash() != "foo/foobar/ns:[]" {
 		t.Errorf("Hash failed: expected: %s, got: %s", "foobar/ns:[]", e.GetHash())
 	}
-	e = AerospikeEndpoint{Name: name, ClusterName: "foo", AutoDiscoverNamespaces: false, Namespaces: ns}
+	e = AerospikeEndpoint{Name: name, ClusterName: "foo", Namespaces: ns}
 	if e.GetHash() != "foo/foobar/ns:[00 bar fo ob]" {
 		t.Errorf("Hash failed: expected: %s, got: %s (order is important)", "foobar/ns:[00 bar fo ob]", e.GetHash())
 	}


### PR DESCRIPTION
This feature is not used and is causing problems when the list of namespace to display is empty