### PR TITLE
Make sure we properly close aerospike client when terminating a probe

### DIFF
--- a/pkg/aerospike/endpoint.go
+++ b/pkg/aerospike/endpoint.go
@@ -157,5 +157,8 @@ func (e *AerospikeEndpoint) Refresh() error {
 }
 
 func (e *AerospikeEndpoint) Close() error {
+	if e != nil {
+		e.Client.Close()
+	}
 	return nil
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -200,6 +200,7 @@ func (pw *ProberWorker) runAllPendingChecks(lastChecks []time.Time) time.Duratio
 
 func (pw *ProberWorker) StartProbing() {
 	level.Info(pw.logger).Log("msg", "starting probing")
+	defer pw.endpoint.Close() // Make sure the client is closed if the probe is stopped
 
 	if len(pw.checks) < 1 {
 		level.Error(pw.logger).Log("msg", "Probe not started no checks registered")
@@ -240,7 +241,7 @@ func (pw *ProberWorker) StartProbing() {
 			}
 			return
 		case <-refreshTicker.C:
-			level.Debug(pw.logger).Log("msg", "Probe endpoint refreshed")
+			level.Debug(pw.logger).Log("msg", "Refreshing probe endpoint")
 			err := pw.endpoint.Refresh()
 			if err != nil {
 				level.Error(pw.logger).Log("msg", "Error while refreshing", "err", err)


### PR DESCRIPTION
The client spawn goroutines that will not be reaped by the GC so we should close it manually