### PR TITLE
Add a debug binary to the blackbox probe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,14 @@ test:
 
 build:
 		go build -o build/aerospike_probe probes/aerospike/main.go
+		# Build for debug:
+		# -N    disable optimizations
+		# -l    disable inlining
+		go build -gcflags="-N -l" -o build/aerospike_probe_debug probes/aerospike/main.go
 
 build_linux:
 		GOOS=linux GOARCH=amd64 go build -o build/aerospike_probe probes/aerospike/*.go
+		GOOS=linux GOARCH=amd64 go build -gcflags="-N -l" -o build/aerospike_probe_debug probes/aerospike/*.go
 
 lint:
 		gofmt -d -e -s pkg/**/*.go probes/**/*.go


### PR DESCRIPTION
The goal is to have an easy access bin to perform remote debugging if needed