### PR TITLE
Switch latency check to cluster check

### DIFF
--- a/probes/aerospike/main.go
+++ b/probes/aerospike/main.go
@@ -74,7 +74,7 @@ func main() {
 	p := scheduler.NewProbingScheduler(log.With(logger), topo)
 
 	if config.AerospikeChecksConfigs.LatencyCheckConfig.Enable {
-		p.RegisterNewNodeCheck(scheduler.Check{
+		p.RegisterNewClusterCheck(scheduler.Check{
 			Name:       "latency_check",
 			PrepareFn:  scheduler.Noop,
 			CheckFn:    aerospike.LatencyCheck,


### PR DESCRIPTION
Since latency checks are made on random nodes of the cluster
the check can be made at the cluster level
This is done to limit the number of client opens and the number of probes to start and stop