### PR TITLE
Fix "Key not found" not handled properly

### DIFF
--- a/pkg/aerospike/checks.go
+++ b/pkg/aerospike/checks.go
@@ -194,7 +194,7 @@ func DurabilityPrepare(p topology.ProbeableEndpoint) error {
 		}
 
 		recVal, err := e.Client.Get(&policy.BasePolicy, allPushedFlag)
-		if err != nil && err.Error() != "Key not found" {
+		if err != nil && err != as.ErrKeyNotFound {
 			level.Debug(e.Logger).Log("msg", "called")
 			return err
 		}


### PR DESCRIPTION
With new version of aerospike we shouldn't compare the
string of errors but the errors directly