### PR TITLE
Disable compression when building blackbox prober

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -31,4 +31,3 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         GHR_PATH: build/
-        GHR_COMPRESS: gz


### PR DESCRIPTION
It doesn't bring much value and it makes it a bit harder to build images