### PR TITLE
Disable cgo when building the probe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,10 @@ test:
 		go test ./...
 
 build:
-		go build -o build/aerospike_probe probes/aerospike/main.go
+		CGO_ENABLED=0 go build -o build/aerospike_probe probes/aerospike/main.go
 
 build_linux:
-		GOOS=linux GOARCH=amd64 go build -o build/aerospike_probe probes/aerospike/*.go
+		CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o build/aerospike_probe probes/aerospike/*.go
 
 lint:
 		gofmt -d -e -s pkg/**/*.go probes/**/*.go


### PR DESCRIPTION
With newer versions of Go the way the default setting for cgo_enabled changed and it results in it being enabled. cgo links the libc which is not practical for deployment on other system/containers. This commit enforce disabling of cgo as it was the case in previous build before bumping Go's version.