### PR TITLE
Fix potential leak of endpoint clients during the initialisation of the probe

### DIFF
--- a/pkg/aerospike/endpoint.go
+++ b/pkg/aerospike/endpoint.go
@@ -120,7 +120,7 @@ func (e *AerospikeEndpoint) Refresh() error {
 }
 
 func (e *AerospikeEndpoint) Close() error {
-	if e != nil {
+	if e != nil && e.Client != nil {
 		e.Client.Close()
 	}
 	return nil

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -174,12 +174,14 @@ func (ps *ProbingScheduler) startNewWorker(endpoint topology.ProbeableEndpoint, 
 	// Make sure the endpoint is connectable
 	err := w.endpoint.Connect()
 	if err != nil {
+		w.endpoint.Close()
 		return errors.Wrapf(err, "Init failure during connection to endpoint %s", w.endpoint.GetHash())
 	}
 
 	// Make sure the probe is able to prepare the endpoint
 	err = w.PrepareProbing()
 	if err != nil {
+		w.endpoint.Close()
 		return errors.Wrapf(err, "Init failure during preparation of endpoint %s", w.endpoint.GetHash())
 	}
 

--- a/pkg/topology/topology.go
+++ b/pkg/topology/topology.go
@@ -20,32 +20,36 @@ type ProbeableEndpoint interface {
 // DummyEndpoint is a fake ProbeableEndpoint that don't do anything
 // Useful for testing
 type DummyEndpoint struct {
-	Name    string
-	Hash    string
-	Cluster bool
+	Name      string
+	Hash      string
+	Cluster   bool
+	Connected bool
+	Closed    bool
 }
 
-func (d DummyEndpoint) GetHash() string {
+func (d *DummyEndpoint) GetHash() string {
 	return d.Hash
 }
 
-func (d DummyEndpoint) GetName() string {
+func (d *DummyEndpoint) GetName() string {
 	return d.Name
 }
 
-func (d DummyEndpoint) IsCluster() bool {
+func (d *DummyEndpoint) IsCluster() bool {
 	return d.Cluster
 }
 
-func (d DummyEndpoint) Connect() error {
+func (d *DummyEndpoint) Connect() error {
+	d.Connected = true
 	return nil
 }
 
-func (d DummyEndpoint) Refresh() error {
+func (d *DummyEndpoint) Refresh() error {
 	return nil
 }
 
-func (d DummyEndpoint) Close() error {
+func (d *DummyEndpoint) Close() error {
+	d.Closed = true
 	return nil
 }
 

--- a/pkg/topology/topology_test.go
+++ b/pkg/topology/topology_test.go
@@ -15,14 +15,14 @@ func TestDiffWorksWithEmptyMap(t *testing.T) {
 }
 
 func TestDiffWorksOnSingleCluster(t *testing.T) {
-	oldCluster := NewCluster(DummyEndpoint{Name: "old_cluster", Hash: "old_cluster1"})
-	oldCluster.AddEndpoint(DummyEndpoint{Name: "old_endpoint", Hash: "old_endpoint1"})
-	oldCluster.AddEndpoint(DummyEndpoint{Name: "old_endpoint", Hash: "old_endpoint2"})
-	oldCluster.AddEndpoint(DummyEndpoint{Name: "old_endpoint3", Hash: "old_endpoint3"})
+	oldCluster := NewCluster(&DummyEndpoint{Name: "old_cluster", Hash: "old_cluster1"})
+	oldCluster.AddEndpoint(&DummyEndpoint{Name: "old_endpoint", Hash: "old_endpoint1"})
+	oldCluster.AddEndpoint(&DummyEndpoint{Name: "old_endpoint", Hash: "old_endpoint2"})
+	oldCluster.AddEndpoint(&DummyEndpoint{Name: "old_endpoint3", Hash: "old_endpoint3"})
 
-	newCluster := NewCluster(DummyEndpoint{Name: "old_cluster", Hash: "old_cluster1"})
-	newCluster.AddEndpoint(DummyEndpoint{Name: "old_endpoint", Hash: "old_endpoint2"})
-	newCluster.AddEndpoint(DummyEndpoint{Name: "old_endpoint3", Hash: "old_endpoint4"})
+	newCluster := NewCluster(&DummyEndpoint{Name: "old_cluster", Hash: "old_cluster1"})
+	newCluster.AddEndpoint(&DummyEndpoint{Name: "old_endpoint", Hash: "old_endpoint2"})
+	newCluster.AddEndpoint(&DummyEndpoint{Name: "old_endpoint3", Hash: "old_endpoint4"})
 
 	oldMap := NewClusterMap()
 	oldMap.AppendCluster(oldCluster)
@@ -45,13 +45,13 @@ func TestDiffWorksOnSingleCluster(t *testing.T) {
 }
 
 func TestDiffWorksOnMultipleClusters(t *testing.T) {
-	oldCluster1 := NewCluster(DummyEndpoint{Name: "old_cluster", Hash: "old_cluster1"})
-	oldCluster1.AddEndpoint(DummyEndpoint{Name: "old_endpoint", Hash: "old_endpoint1"})
-	oldCluster2 := NewCluster(DummyEndpoint{Name: "old_cluster", Hash: "old_cluster2"})
-	oldCluster2.AddEndpoint(DummyEndpoint{Name: "old_endpoint", Hash: "old_endpoint2"})
+	oldCluster1 := NewCluster(&DummyEndpoint{Name: "old_cluster", Hash: "old_cluster1"})
+	oldCluster1.AddEndpoint(&DummyEndpoint{Name: "old_endpoint", Hash: "old_endpoint1"})
+	oldCluster2 := NewCluster(&DummyEndpoint{Name: "old_cluster", Hash: "old_cluster2"})
+	oldCluster2.AddEndpoint(&DummyEndpoint{Name: "old_endpoint", Hash: "old_endpoint2"})
 
-	newCluster2 := NewCluster(DummyEndpoint{Name: "new_cluster", Hash: "new_cluster1"})
-	newCluster2.AddEndpoint(DummyEndpoint{Name: "new_endpoint", Hash: "new_endpoint1"})
+	newCluster2 := NewCluster(&DummyEndpoint{Name: "new_cluster", Hash: "new_cluster1"})
+	newCluster2.AddEndpoint(&DummyEndpoint{Name: "new_endpoint", Hash: "new_endpoint1"})
 
 	oldMap := NewClusterMap()
 	oldMap.AppendCluster(oldCluster1)


### PR DESCRIPTION
it was possible to not close an endpoint when a probe failed to start. If it failed during connect or during the execution of prepareFn, it was not closed.

Also added a lot of unit testing on the scheduler