### PR TITLE
Add configurable total timeout parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 main
 build/
 .vscode/
+.idea/
+conf.yaml

--- a/pkg/aerospike/config.go
+++ b/pkg/aerospike/config.go
@@ -52,6 +52,7 @@ type AerospikeEndpointConfig struct {
 	OpeningConnectionThreshold        int           `yaml:"opening_connection_threshold,omitempty"`
 	MinConnectionsPerNode             int           `yaml:"min_connections_per_node,omitempty"`
 	TendInterval                      time.Duration `yaml:"tend_interval,omitempty"`
+	TotalTimeout                      time.Duration `yaml:"total_timeout,omitempty"`
 	ExitFastOnExhaustedConnectionPool bool          `yaml:"exit_fast_on_exhausted_connection_pool,omitempty"`
 }
 
@@ -72,6 +73,7 @@ var (
 		OpeningConnectionThreshold:        0,
 		MinConnectionsPerNode:             0,
 		TendInterval:                      time.Second,
+		TotalTimeout:                      30 * time.Second,
 		ExitFastOnExhaustedConnectionPool: false,
 	}
 )


### PR DESCRIPTION
  - Since we bumped from v5 to v7 of the Aerospike client the default timeout went from 0 (no timeout) to 1 second.
  - This change adds a configuration option to specify this value (total_timeout, e.g. "30s" in the yaml config). The default value is 30s
  - We also use explicitly (for readability) 2 retries for the durability checks (read and write policies): this is the default for read (aka. base) policy, while the default for write policiy is 0