### PR TITLE
rework availability check for opensearch

### DIFF
--- a/cmd/opensearch/main.go
+++ b/cmd/opensearch/main.go
@@ -60,6 +60,15 @@ func main() {
 	// Scheduler stuff
 	p := scheduler.NewProbingScheduler(log.With(logger), topo)
 
+	if config.OpenSearchChecksConfigs.AvailabilityCheckConfig.Enable {
+		p.RegisterNewClusterCheck(scheduler.Check{
+			Name:       "availability_check",
+			PrepareFn:  opensearch.AvailabilityPrepare,
+			CheckFn:    opensearch.AvailabilityCheck,
+			TeardownFn: scheduler.Noop,
+			Interval:   config.OpenSearchChecksConfigs.LatencyCheckConfig.Interval,
+		})
+	}
 	if config.OpenSearchChecksConfigs.LatencyCheckConfig.Enable {
 		p.RegisterNewClusterCheck(scheduler.Check{
 			Name:       "latency_check",

--- a/conf_os.yaml
+++ b/conf_os.yaml
@@ -22,6 +22,9 @@ client_config:
   # Skip TLS verification
   insecure_skip_verify: true
 checks_configs:
+  availability_check:
+    enable: true
+    interval: 30s
   latency_check:
     enable: true
     interval: 500ms

--- a/pkg/aerospike/checks.go
+++ b/pkg/aerospike/checks.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
+	"github.com/criteo/blackbox-prober/pkg/common"
 	"github.com/criteo/blackbox-prober/pkg/topology"
 	"github.com/criteo/blackbox-prober/pkg/utils"
 	"github.com/go-kit/log/level"
@@ -116,7 +117,7 @@ func LatencyCheck(p topology.ProbeableEndpoint) error {
 		}
 
 		// lookup node fqdn and pod name associated to aerospike endpoint
-		nodeInfo := &AerospikeNodeInfo{NodeName: node.GetHost().Name, NodeFqdn: "unknown", PodName: "unknown"}
+		nodeInfo := &common.ClusterNodeInfo{NodeName: node.GetHost().Name, NodeFqdn: "unknown", PodName: "unknown"}
 		if ni, found := e.ClusterConfig.nodeInfoCache[node.GetHost().Name]; found {
 			nodeInfo = ni
 		}

--- a/pkg/aerospike/config.go
+++ b/pkg/aerospike/config.go
@@ -6,16 +6,11 @@ import (
 	as "github.com/aerospike/aerospike-client-go/v8"
 	asl "github.com/aerospike/aerospike-client-go/v8/logger"
 	"github.com/alecthomas/kingpin/v2"
+	"github.com/criteo/blackbox-prober/pkg/common"
 	"github.com/criteo/blackbox-prober/pkg/discovery"
 	"github.com/criteo/blackbox-prober/pkg/scheduler"
 	"github.com/pkg/errors"
 )
-
-type AerospikeNodeInfo struct {
-	NodeName string // node name as returned by Aerospike driver
-	PodName  string // name of the pod running this Aerospike node
-	NodeFqdn string // fqdn of the physical node running the pod
-}
 
 // Config used to configure the client of Aerospike
 type AerospikeClientConfig struct {
@@ -33,7 +28,7 @@ type AerospikeClientConfig struct {
 	genericConfig *AerospikeEndpointConfig
 
 	// a map keeping information about nodes to enrich metrics
-	nodeInfoCache map[string]*AerospikeNodeInfo
+	nodeInfoCache map[string]*common.ClusterNodeInfo
 }
 
 // Config used to configure the endpoint of Aerospike

--- a/pkg/aerospike/discovery.go
+++ b/pkg/aerospike/discovery.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
+	"github.com/criteo/blackbox-prober/pkg/common"
 	"github.com/criteo/blackbox-prober/pkg/discovery"
 	"github.com/criteo/blackbox-prober/pkg/topology"
 	"github.com/criteo/blackbox-prober/pkg/utils"
@@ -48,9 +49,9 @@ func (conf *AerospikeProbeConfig) buildClusterClientConfig(logger log.Logger, en
 		clusterName = entries[0].Address
 	}
 
-	nodeInfoCache := map[string]*AerospikeNodeInfo{}
+	nodeInfoCache := map[string]*common.ClusterNodeInfo{}
 	for _, entry := range entries {
-		nodeInfoCache[entry.Address] = &AerospikeNodeInfo{
+		nodeInfoCache[entry.Address] = &common.ClusterNodeInfo{
 			NodeName: entry.Address,
 			PodName:  entry.PodName,
 			NodeFqdn: entry.NodeFqdn,

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -16,6 +16,12 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
+type ClusterNodeInfo struct {
+	NodeName string // node name as returned by database
+	PodName  string // name of the pod running this Aerospike node
+	NodeFqdn string // fqdn of the physical node running the pod
+}
+
 type ProbeConfig struct {
 	LogConfig      promlog.Config `yaml:"log,omitempty"`
 	HttpListenAddr string         `yaml:"http_listen_addr,omitempty"`

--- a/pkg/common/config.go
+++ b/pkg/common/config.go
@@ -18,6 +18,7 @@ import (
 
 type ClusterNodeInfo struct {
 	NodeName string // node name as returned by database
+	NodeIP   string // node ip
 	PodName  string // name of the pod running this Aerospike node
 	NodeFqdn string // fqdn of the physical node running the pod
 }

--- a/pkg/opensearch/checks.go
+++ b/pkg/opensearch/checks.go
@@ -74,6 +74,35 @@ var clusterErrorsCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Help: "Total number of errors in the cluster",
 }, []string{"cluster"})
 
+func AvailabilityPrepare(p topology.ProbeableEndpoint) error {
+	return nil
+}
+
+func AvailabilityCheck(p topology.ProbeableEndpoint) error {
+	e, ok := p.(*OpenSearchEndpoint)
+	if !ok {
+		return fmt.Errorf("error: given endpoint is not an opensearch endpoint")
+	}
+
+	catNodes, err := e.catNodes()
+	if err != nil {
+		return errorHandler(fmt.Errorf("failed to get cat nodes for %s: %s", e.Name, err), e.ClusterName)
+	}
+
+	nodeAvailability.DeleteLabelValues(e.ClusterName)
+	for _, nodeInfo := range e.nodeInfoCache {
+		nodeAvailability.WithLabelValues(e.ClusterName, nodeInfo.NodeFqdn, nodeInfo.PodName).Set(0)
+	}
+	for _, node := range catNodes {
+		if ni, found := e.nodeInfoCache[node]; found {
+			// Set node availability metric to 1 on success
+			nodeAvailability.WithLabelValues(e.ClusterName, ni.NodeFqdn, ni.PodName).Set(1)
+		}
+	}
+
+	return nil
+}
+
 // ObserveOpLatency measures the latency of the given operation function 'op' and records it in the opLatency histogram.
 // It also increments the opFailuresTotal counter if the operation results in an error.
 func ObserveOpLatency(op func() error, labels []string) error {
@@ -96,7 +125,6 @@ func LatencyPrepare(p topology.ProbeableEndpoint) error {
 
 	// Init cluster and node error count metric
 	clusterErrorsCount.WithLabelValues(e.ClusterName).Set(0)
-	nodeAvailability.WithLabelValues(e.ClusterName, e.NodeFqdn, e.PodName).Set(0)
 
 	// Check if latency index exists, create it if it does not
 	exists, err := e.checkIndexExists(LATENCY_INDEX_NAME)
@@ -196,19 +224,13 @@ func LatencyCheck(p topology.ProbeableEndpoint) error {
 
 	// CAT HEALTH
 	labels = []string{"cat_health", e.Name, e.ClusterName, LATENCY_INDEX_NAME}
-	labelsAvailability := []string{e.ClusterName, e.NodeFqdn, e.PodName}
 	opCat := func() error {
 		return e.catHealth()
 	}
-
 	err = ObserveOpLatency(opCat, labels)
 	if err != nil {
-		// Set node availability metric to 0 on failure
-		nodeAvailability.WithLabelValues(labelsAvailability...).Set(0)
 		return errorHandler(fmt.Errorf("failed to get cat health for %s: %s", e.Name, err), e.ClusterName)
 	}
-	// Set node availability metric to 1 on success
-	nodeAvailability.WithLabelValues(labelsAvailability...).Set(1)
 
 	level.Debug(e.Logger).Log("msg", fmt.Sprintf("cat health success for: %s", e.Name))
 

--- a/pkg/opensearch/checks_test.go
+++ b/pkg/opensearch/checks_test.go
@@ -1,0 +1,214 @@
+package opensearch
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/criteo/blackbox-prober/pkg/common"
+	"github.com/go-kit/log"
+	opensearch "github.com/opensearch-project/opensearch-go/v4"
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// newTestEndpoint creates an OpenSearchEndpoint backed by the given test server.
+func newTestEndpoint(t *testing.T, server *httptest.Server, nodeInfoCache map[string]*common.ClusterNodeInfo) *OpenSearchEndpoint {
+	t.Helper()
+	cfg := opensearchapi.Config{
+		Client: opensearch.Config{
+			Addresses: []string{server.URL},
+		},
+	}
+	client, err := opensearchapi.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("failed to create test client: %v", err)
+	}
+	return &OpenSearchEndpoint{
+		Name:          "test-cluster",
+		ClusterName:   "test-cluster",
+		ClusterLevel:  true,
+		Client:        client,
+		ClientConfig:  cfg,
+		Logger:        log.NewNopLogger(),
+		nodeInfoCache: nodeInfoCache,
+	}
+}
+
+// catNodesMux returns an http.Handler that serves /_cat/nodes with the given node names.
+func catNodesMux(t *testing.T, nodeNames []string) http.Handler {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc("/_cat/nodes", func(w http.ResponseWriter, r *http.Request) {
+		type node struct {
+			Name string `json:"name"`
+			IP   string `json:"ip"`
+			Port int    `json:"port,string"`
+		}
+		nodes := make([]node, len(nodeNames))
+		for i, n := range nodeNames {
+			nodes[i] = node{Name: n, IP: "10.0.0.1", Port: 9200}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(nodes)
+	})
+	return mux
+}
+
+func TestAvailabilityCheckAllNodesAvailable(t *testing.T) {
+	// Reset the metric to avoid pollution from other tests
+	nodeAvailability.Reset()
+
+	server := httptest.NewServer(catNodesMux(t, []string{"pod-1", "pod-2"}))
+	defer server.Close()
+
+	cache := map[string]*common.ClusterNodeInfo{
+		"pod-1": {NodeIP: "10.0.0.1", PodName: "pod-1", NodeFqdn: "node1.example.com"},
+		"pod-2": {NodeIP: "10.0.0.2", PodName: "pod-2", NodeFqdn: "node2.example.com"},
+	}
+	endpoint := newTestEndpoint(t, server, cache)
+
+	err := AvailabilityCheck(endpoint)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Both nodes should have availability = 1
+	val1 := testutil.ToFloat64(nodeAvailability.WithLabelValues("test-cluster", "node1.example.com", "pod-1"))
+	if val1 != 1 {
+		t.Fatalf("expected node availability 1 for pod-1, got %v", val1)
+	}
+	val2 := testutil.ToFloat64(nodeAvailability.WithLabelValues("test-cluster", "node2.example.com", "pod-2"))
+	if val2 != 1 {
+		t.Fatalf("expected node availability 1 for pod-2, got %v", val2)
+	}
+}
+
+func TestAvailabilityCheckPartialNodes(t *testing.T) {
+	nodeAvailability.Reset()
+
+	// catNodes only returns pod-1, pod-2 is missing from the cluster
+	server := httptest.NewServer(catNodesMux(t, []string{"pod-1"}))
+	defer server.Close()
+
+	cache := map[string]*common.ClusterNodeInfo{
+		"pod-1": {NodeIP: "10.0.0.1", PodName: "pod-1", NodeFqdn: "node1.example.com"},
+		"pod-2": {NodeIP: "10.0.0.2", PodName: "pod-2", NodeFqdn: "node2.example.com"},
+	}
+	endpoint := newTestEndpoint(t, server, cache)
+
+	err := AvailabilityCheck(endpoint)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	val1 := testutil.ToFloat64(nodeAvailability.WithLabelValues("test-cluster", "node1.example.com", "pod-1"))
+	if val1 != 1 {
+		t.Fatalf("expected node availability 1 for pod-1, got %v", val1)
+	}
+	// pod-2 not returned by catNodes → should remain 0
+	val2 := testutil.ToFloat64(nodeAvailability.WithLabelValues("test-cluster", "node2.example.com", "pod-2"))
+	if val2 != 0 {
+		t.Fatalf("expected node availability 0 for pod-2, got %v", val2)
+	}
+}
+
+func TestAvailabilityCheckNoNodesReturned(t *testing.T) {
+	nodeAvailability.Reset()
+
+	server := httptest.NewServer(catNodesMux(t, []string{}))
+	defer server.Close()
+
+	cache := map[string]*common.ClusterNodeInfo{
+		"pod-1": {NodeIP: "10.0.0.1", PodName: "pod-1", NodeFqdn: "node1.example.com"},
+	}
+	endpoint := newTestEndpoint(t, server, cache)
+
+	err := AvailabilityCheck(endpoint)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	val := testutil.ToFloat64(nodeAvailability.WithLabelValues("test-cluster", "node1.example.com", "pod-1"))
+	if val != 0 {
+		t.Fatalf("expected node availability 0 when no nodes returned, got %v", val)
+	}
+}
+
+func TestAvailabilityCheckUnknownNodeIgnored(t *testing.T) {
+	nodeAvailability.Reset()
+
+	// catNodes returns a node not in the cache
+	server := httptest.NewServer(catNodesMux(t, []string{"pod-1", "unknown-pod"}))
+	defer server.Close()
+
+	cache := map[string]*common.ClusterNodeInfo{
+		"pod-1": {NodeIP: "10.0.0.1", PodName: "pod-1", NodeFqdn: "node1.example.com"},
+	}
+	endpoint := newTestEndpoint(t, server, cache)
+
+	err := AvailabilityCheck(endpoint)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	val := testutil.ToFloat64(nodeAvailability.WithLabelValues("test-cluster", "node1.example.com", "pod-1"))
+	if val != 1 {
+		t.Fatalf("expected node availability 1 for pod-1, got %v", val)
+	}
+
+	// Only 1 metric series should exist for this cluster (the known node)
+	count := testutil.CollectAndCount(nodeAvailability)
+	if count != 1 {
+		t.Fatalf("expected 1 metric series, got %d", count)
+	}
+}
+
+func TestAvailabilityCheckCatNodesError(t *testing.T) {
+	nodeAvailability.Reset()
+	clusterErrorsCount.Reset()
+
+	// Return 500 to simulate a failure
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	cache := map[string]*common.ClusterNodeInfo{
+		"pod-1": {NodeIP: "10.0.0.1", PodName: "pod-1", NodeFqdn: "node1.example.com"},
+	}
+	endpoint := newTestEndpoint(t, server, cache)
+
+	err := AvailabilityCheck(endpoint)
+	if err == nil {
+		t.Fatal("expected error when catNodes fails")
+	}
+
+	// Cluster error count should have been incremented
+	errCount := testutil.ToFloat64(clusterErrorsCount.WithLabelValues("test-cluster"))
+	if errCount != 1 {
+		t.Fatalf("expected cluster error count 1, got %v", errCount)
+	}
+}
+
+func TestAvailabilityCheckWrongEndpointType(t *testing.T) {
+	err := AvailabilityCheck(&fakeEndpoint{})
+	if err == nil {
+		t.Fatal("expected error for wrong endpoint type")
+	}
+	expected := "error: given endpoint is not an opensearch endpoint"
+	if err.Error() != expected {
+		t.Fatalf("expected error %q, got %q", expected, err.Error())
+	}
+}
+
+// fakeEndpoint implements ProbeableEndpoint but is NOT an OpenSearchEndpoint.
+type fakeEndpoint struct{}
+
+func (f *fakeEndpoint) GetHash() string { return "fake" }
+func (f *fakeEndpoint) GetName() string { return "fake" }
+func (f *fakeEndpoint) IsCluster() bool { return false }
+func (f *fakeEndpoint) Connect() error  { return nil }
+func (f *fakeEndpoint) Refresh() error  { return nil }
+func (f *fakeEndpoint) Close() error    { return nil }

--- a/pkg/opensearch/config.go
+++ b/pkg/opensearch/config.go
@@ -52,6 +52,7 @@ type OpenSearchProbeConfig struct {
 }
 
 type OpenSearchChecksConfigs struct {
-	LatencyCheckConfig    scheduler.CheckConfig `yaml:"latency_check,omitempty"`
-	DurabilityCheckConfig scheduler.CheckConfig `yaml:"durability_check,omitempty"`
+	AvailabilityCheckConfig scheduler.CheckConfig `yaml:"availability_check,omitempty"`
+	LatencyCheckConfig      scheduler.CheckConfig `yaml:"latency_check,omitempty"`
+	DurabilityCheckConfig   scheduler.CheckConfig `yaml:"durability_check,omitempty"`
 }

--- a/pkg/opensearch/discovery.go
+++ b/pkg/opensearch/discovery.go
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
+	"github.com/criteo/blackbox-prober/pkg/common"
 	"github.com/criteo/blackbox-prober/pkg/discovery"
 	"github.com/criteo/blackbox-prober/pkg/topology"
 	"github.com/criteo/blackbox-prober/pkg/utils"
@@ -15,21 +17,40 @@ import (
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 )
 
-func (conf *OpenSearchProbeConfig) buildAddress(tlsEnabled bool, entry discovery.ServiceEntry) string {
+func (conf *OpenSearchProbeConfig) buildAddress(entry discovery.ServiceEntry) string {
 	proto := "http"
-	if tlsEnabled {
+	if utils.Contains(entry.Tags, conf.OpenSearchEndpointConfig.TLSTag) {
 		proto = "https"
 	}
 
 	return fmt.Sprintf("%s://%s", proto, fmt.Sprintf("%s:%d", entry.Address, entry.Port))
 }
 
-func (conf *OpenSearchProbeConfig) buildOpenSearchEndpoint(logger log.Logger, clusterName string, entry discovery.ServiceEntry) (*OpenSearchEndpoint, error) {
+func (conf *OpenSearchProbeConfig) buildOpenSearchEndpoint(logger log.Logger, entries []discovery.ServiceEntry) (*OpenSearchEndpoint, error) {
 	// Init Client Config
-	tlsEnabled := utils.Contains(entry.Tags, conf.OpenSearchEndpointConfig.TLSTag)
+	tlsEnabled := false
+
+	nodeInfoCache := map[string]*common.ClusterNodeInfo{} // a map keeping information about nodes to enrich metrics
+	seeds := []string{}
+	for _, entry := range entries {
+		contactPoint := conf.buildAddress(entry)
+		seeds = append(seeds, contactPoint)
+		if strings.HasPrefix(contactPoint, "https") {
+			tlsEnabled = true
+		}
+
+		nodeInfoCache[entry.PodName] = &common.ClusterNodeInfo{
+			NodeIP:   entry.Address,
+			PodName:  entry.PodName,
+			NodeFqdn: entry.NodeFqdn,
+		}
+	}
+
 	clientConfig := opensearchapi.Config{
 		Client: opensearch.Config{
-			Addresses: []string{conf.buildAddress(tlsEnabled, entry)},
+			Addresses:             seeds,
+			DiscoverNodesOnStart:  true, // sniffing enabled to retrieve topology updates before consul
+			DiscoverNodesInterval: 30 * time.Second,
 		},
 	}
 
@@ -64,41 +85,18 @@ func (conf *OpenSearchProbeConfig) buildOpenSearchEndpoint(logger log.Logger, cl
 		clientConfig.Client.Password = password
 	}
 
+	clusterName := conf.valueFromTags("cluster_name", entries[0].Tags)
 	endpoint := &OpenSearchEndpoint{
-		Name:         entry.Address,
-		PodName:      entry.Meta["k8s_pod"],
-		NodeFqdn:     entry.NodeFqdn,
-		ClusterName:  conf.valueFromTags("cluster_name", entry.Tags),
-		ClusterLevel: true,
-		ClientConfig: clientConfig,
-		Config:       conf.OpenSearchEndpointConfig,
-		Logger:       log.With(logger, "endpoint_name", entry.Address),
+		Name:          clusterName,
+		ClusterName:   clusterName,
+		ClusterLevel:  true,
+		ClientConfig:  clientConfig,
+		Config:        conf.OpenSearchEndpointConfig,
+		Logger:        log.With(logger, "endpoint_name", clusterName),
+		nodeInfoCache: nodeInfoCache,
 	}
 
 	return endpoint, nil
-}
-
-func (conf *OpenSearchProbeConfig) generateClusterEndpointFromEntries(logger log.Logger, entries []discovery.ServiceEntry) (topology.ProbeableEndpoint, error) {
-	if len(entries) == 0 {
-		return nil, fmt.Errorf("no entries provided")
-	}
-
-	entry := entries[0]
-
-	clusterName, ok := entry.Meta[conf.DiscoveryConfig.MetaClusterKey]
-	if !ok {
-		return nil, fmt.Errorf("cluster name not found in meta key: %s", conf.DiscoveryConfig.MetaClusterKey)
-	}
-
-	return conf.buildOpenSearchEndpoint(logger, clusterName, entry)
-}
-
-func (conf *OpenSearchProbeConfig) generateNodeEndpointFromEntry(logger log.Logger, entry discovery.ServiceEntry) (topology.ProbeableEndpoint, error) {
-	clusterName, ok := entry.Meta[conf.DiscoveryConfig.MetaClusterKey]
-	if !ok {
-		clusterName = entry.Address
-	}
-	return conf.buildOpenSearchEndpoint(logger, clusterName, entry)
 }
 
 func (conf *OpenSearchProbeConfig) valueFromTags(prefix string, serviceTags []string) string {
@@ -112,5 +110,19 @@ func (conf *OpenSearchProbeConfig) valueFromTags(prefix string, serviceTags []st
 }
 
 func (conf *OpenSearchProbeConfig) BuildTopology(logger log.Logger, entries []discovery.ServiceEntry) (topology.ClusterMap, error) {
-	return conf.DiscoveryConfig.BuildTopology(logger, entries, conf.generateClusterEndpointFromEntries, conf.generateNodeEndpointFromEntry)
+	clusterMap := topology.NewClusterMap()
+	clusterEntries := conf.DiscoveryConfig.GroupNodesByCluster(logger, entries)
+	for serviceName, entries := range clusterEntries {
+		if len(entries) == 0 {
+			return clusterMap, fmt.Errorf("no service instances found for %s", serviceName)
+		}
+
+		clusterEndpoint, err := conf.buildOpenSearchEndpoint(logger, entries)
+		if err != nil {
+			return clusterMap, err
+		}
+		cluster := topology.NewCluster(clusterEndpoint)
+		clusterMap.AppendCluster(cluster)
+	}
+	return clusterMap, nil
 }

--- a/pkg/opensearch/discovery_test.go
+++ b/pkg/opensearch/discovery_test.go
@@ -1,0 +1,294 @@
+package opensearch
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/criteo/blackbox-prober/pkg/discovery"
+	"github.com/go-kit/log"
+)
+
+func TestBuildAddress(t *testing.T) {
+	conf := OpenSearchProbeConfig{
+		OpenSearchEndpointConfig: OpenSearchEndpointConfig{
+			TLSTag: "tls",
+		},
+	}
+
+	tests := []struct {
+		name     string
+		entry    discovery.ServiceEntry
+		expected string
+	}{
+		{
+			name: "NoTLSTag",
+			entry: discovery.ServiceEntry{
+				Address: "10.0.0.1",
+				Port:    9200,
+				Tags:    []string{"cluster_name-mycluster"},
+			},
+			expected: "http://10.0.0.1:9200",
+		},
+		{
+			name: "WithTLSTag",
+			entry: discovery.ServiceEntry{
+				Address: "10.0.0.1",
+				Port:    9200,
+				Tags:    []string{"tls", "cluster_name-mycluster"},
+			},
+			expected: "https://10.0.0.1:9200",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := conf.buildAddress(tt.entry)
+			if got != tt.expected {
+				t.Fatalf("expected %q, got %q", tt.expected, got)
+			}
+		})
+	}
+}
+
+func TestBuildOpenSearchEndpoint(t *testing.T) {
+	conf := OpenSearchProbeConfig{
+		OpenSearchEndpointConfig: OpenSearchEndpointConfig{
+			AuthEnabled: false,
+			TLSTag:      "tls",
+		},
+	}
+
+	entries := []discovery.ServiceEntry{
+		{
+			Address:  "10.0.0.1",
+			Port:     9200,
+			Tags:     []string{"cluster_name-mycluster"},
+			PodName:  "pod-1",
+			NodeFqdn: "node1.example.com",
+		},
+		{
+			Address:  "10.0.0.2",
+			Port:     9200,
+			Tags:     []string{"cluster_name-mycluster"},
+			PodName:  "pod-2",
+			NodeFqdn: "node2.example.com",
+		},
+	}
+
+	endpoint, err := conf.buildOpenSearchEndpoint(log.NewNopLogger(), entries)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Cluster name from tags
+	if endpoint.ClusterName != "mycluster" {
+		t.Fatalf("expected cluster name %q, got %q", "mycluster", endpoint.ClusterName)
+	}
+	if endpoint.Name != "mycluster" {
+		t.Fatalf("expected name %q, got %q", "mycluster", endpoint.Name)
+	}
+	if !endpoint.ClusterLevel {
+		t.Fatal("expected endpoint to be cluster level")
+	}
+
+	// nodeInfoCache should contain both pods
+	if len(endpoint.nodeInfoCache) != 2 {
+		t.Fatalf("expected 2 entries in nodeInfoCache, got %d", len(endpoint.nodeInfoCache))
+	}
+	ni1 := endpoint.nodeInfoCache["pod-1"]
+	if ni1 == nil {
+		t.Fatal("expected pod-1 in nodeInfoCache")
+	}
+	if ni1.NodeIP != "10.0.0.1" || ni1.NodeFqdn != "node1.example.com" || ni1.PodName != "pod-1" {
+		t.Fatalf("unexpected nodeInfoCache entry for pod-1: %+v", ni1)
+	}
+	ni2 := endpoint.nodeInfoCache["pod-2"]
+	if ni2 == nil {
+		t.Fatal("expected pod-2 in nodeInfoCache")
+	}
+	if ni2.NodeIP != "10.0.0.2" || ni2.NodeFqdn != "node2.example.com" || ni2.PodName != "pod-2" {
+		t.Fatalf("unexpected nodeInfoCache entry for pod-2: %+v", ni2)
+	}
+
+	// Seeds should have both addresses
+	addresses := endpoint.ClientConfig.Client.Addresses
+	if len(addresses) != 2 {
+		t.Fatalf("expected 2 seed addresses, got %d", len(addresses))
+	}
+	if addresses[0] != "http://10.0.0.1:9200" {
+		t.Fatalf("expected first seed %q, got %q", "http://10.0.0.1:9200", addresses[0])
+	}
+	if addresses[1] != "http://10.0.0.2:9200" {
+		t.Fatalf("expected second seed %q, got %q", "http://10.0.0.2:9200", addresses[1])
+	}
+
+	// Sniffing config
+	if !endpoint.ClientConfig.Client.DiscoverNodesOnStart {
+		t.Fatal("expected DiscoverNodesOnStart to be true")
+	}
+	if endpoint.ClientConfig.Client.DiscoverNodesInterval != 30*time.Second {
+		t.Fatalf("expected DiscoverNodesInterval 30s, got %v", endpoint.ClientConfig.Client.DiscoverNodesInterval)
+	}
+}
+
+func TestBuildOpenSearchEndpointWithTLS(t *testing.T) {
+	conf := OpenSearchProbeConfig{
+		OpenSearchEndpointConfig: OpenSearchEndpointConfig{
+			AuthEnabled:        false,
+			TLSTag:             "tls",
+			InsecureSkipVerify: true,
+		},
+	}
+
+	entries := []discovery.ServiceEntry{
+		{
+			Address:  "10.0.0.1",
+			Port:     9200,
+			Tags:     []string{"tls", "cluster_name-securecluster"},
+			PodName:  "pod-1",
+			NodeFqdn: "node1.example.com",
+		},
+	}
+
+	endpoint, err := conf.buildOpenSearchEndpoint(log.NewNopLogger(), entries)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if endpoint.ClientConfig.Client.Addresses[0] != "https://10.0.0.1:9200" {
+		t.Fatalf("expected https address, got %q", endpoint.ClientConfig.Client.Addresses[0])
+	}
+
+	// Transport should be configured for InsecureSkipVerify
+	if endpoint.ClientConfig.Client.Transport == nil {
+		t.Fatal("expected Transport to be set for TLS with InsecureSkipVerify")
+	}
+}
+
+func TestBuildOpenSearchEndpointWithAuth(t *testing.T) {
+	conf := OpenSearchProbeConfig{
+		OpenSearchEndpointConfig: OpenSearchEndpointConfig{
+			AuthEnabled: true,
+			UsernameEnv: "OS_TEST_USER",
+			PasswordEnv: "OS_TEST_PASS",
+			TLSTag:      "tls",
+		},
+	}
+
+	t.Setenv("OS_TEST_USER", "admin")
+	t.Setenv("OS_TEST_PASS", "secret")
+
+	entries := []discovery.ServiceEntry{
+		{
+			Address:  "10.0.0.1",
+			Port:     9200,
+			Tags:     []string{"cluster_name-authcluster"},
+			PodName:  "pod-1",
+			NodeFqdn: "node1.example.com",
+		},
+	}
+
+	endpoint, err := conf.buildOpenSearchEndpoint(log.NewNopLogger(), entries)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if endpoint.ClientConfig.Client.Username != "admin" {
+		t.Fatalf("expected username %q, got %q", "admin", endpoint.ClientConfig.Client.Username)
+	}
+	if endpoint.ClientConfig.Client.Password != "secret" {
+		t.Fatalf("expected password %q, got %q", "secret", endpoint.ClientConfig.Client.Password)
+	}
+}
+
+func TestBuildOpenSearchEndpointAuthMissingEnv(t *testing.T) {
+	usernameEnv := fmt.Sprintf("OS_TEST_USER_%d", time.Now().UnixNano())
+	passwordEnv := fmt.Sprintf("OS_TEST_PASS_%d", time.Now().UnixNano())
+
+	conf := OpenSearchProbeConfig{
+		OpenSearchEndpointConfig: OpenSearchEndpointConfig{
+			AuthEnabled: true,
+			UsernameEnv: usernameEnv,
+			PasswordEnv: passwordEnv,
+			TLSTag:      "tls",
+		},
+	}
+
+	_ = os.Unsetenv(usernameEnv)
+	_ = os.Unsetenv(passwordEnv)
+
+	entries := []discovery.ServiceEntry{
+		{
+			Address:  "10.0.0.1",
+			Port:     9200,
+			Tags:     []string{"cluster_name-mycluster"},
+			PodName:  "pod-1",
+			NodeFqdn: "node1.example.com",
+		},
+	}
+
+	_, err := conf.buildOpenSearchEndpoint(log.NewNopLogger(), entries)
+	if err == nil {
+		t.Fatal("expected error when auth env vars are missing")
+	}
+
+	expected := fmt.Sprintf("error: username not found in env (%s)", usernameEnv)
+	if err.Error() != expected {
+		t.Fatalf("expected error %q, got %q", expected, err.Error())
+	}
+}
+
+func TestBuildTopology(t *testing.T) {
+	conf := OpenSearchProbeConfig{
+		DiscoveryConfig: discovery.GenericDiscoveryConfig{
+			MetaClusterKey: "CLUSTER",
+		},
+		OpenSearchEndpointConfig: OpenSearchEndpointConfig{
+			AuthEnabled: false,
+			TLSTag:      "tls",
+		},
+	}
+
+	entries := []discovery.ServiceEntry{
+		{
+			Service:  "opensearch",
+			Address:  "10.0.0.1",
+			Port:     9200,
+			Tags:     []string{"cluster_name-cluster1"},
+			PodName:  "pod-1",
+			NodeFqdn: "node1.example.com",
+			Meta:     map[string]string{"CLUSTER": "cluster1"},
+		},
+		{
+			Service:  "opensearch",
+			Address:  "10.0.0.2",
+			Port:     9200,
+			Tags:     []string{"cluster_name-cluster1"},
+			PodName:  "pod-2",
+			NodeFqdn: "node2.example.com",
+			Meta:     map[string]string{"CLUSTER": "cluster1"},
+		},
+	}
+
+	clusterMap, err := conf.BuildTopology(log.NewNopLogger(), entries)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(clusterMap.Clusters) != 1 {
+		t.Fatalf("expected 1 cluster, got %d", len(clusterMap.Clusters))
+	}
+
+	var ep *OpenSearchEndpoint
+	for _, cluster := range clusterMap.Clusters {
+		ep = cluster.ClusterEndpoint.(*OpenSearchEndpoint)
+	}
+	if ep.ClusterName != "cluster1" {
+		t.Fatalf("expected cluster name %q, got %q", "cluster1", ep.ClusterName)
+	}
+	if len(ep.nodeInfoCache) != 2 {
+		t.Fatalf("expected 2 entries in nodeInfoCache, got %d", len(ep.nodeInfoCache))
+	}
+}

--- a/pkg/opensearch/endpoint.go
+++ b/pkg/opensearch/endpoint.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/criteo/blackbox-prober/pkg/common"
 	"github.com/go-kit/log"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"github.com/opensearch-project/opensearch-go/v4/opensearchutil"
@@ -17,12 +18,13 @@ type OpenSearchEndpoint struct {
 	Name         string
 	ClusterLevel bool
 	ClusterName  string
-	PodName      string
-	NodeFqdn     string
 	Client       *opensearchapi.Client
 	ClientConfig opensearchapi.Config
 	Config       OpenSearchEndpointConfig
 	Logger       log.Logger
+
+	// a map keeping information about nodes to enrich metrics
+	nodeInfoCache map[string]*common.ClusterNodeInfo
 }
 
 func (e *OpenSearchEndpoint) GetHash() string {
@@ -384,4 +386,23 @@ func (e *OpenSearchEndpoint) catHealth() error {
 	}
 
 	return nil
+}
+
+func (e *OpenSearchEndpoint) catNodes() ([]string, error) {
+	ctx := context.Background()
+	nodes := []string{}
+	response, err := e.Client.Cat.Nodes(ctx, &opensearchapi.CatNodesReq{})
+	if err != nil {
+		return nodes, fmt.Errorf("error getting cat nodes: %v", err)
+	}
+
+	if response.Inspect().Response.StatusCode != 200 {
+		return nodes, fmt.Errorf("unexpected status code %d when getting cat node", response.Inspect().Response.StatusCode)
+	}
+
+	for _, node := range response.Nodes {
+		nodes = append(nodes, node.Name)
+	}
+
+	return nodes, nil
 }


### PR DESCRIPTION
rework availability check for opensearch

make a dedicated availability check that compare consul discovery versus nodes reported by cluster

it should fix probe struggling to schedule endpoint:
* probe was creating both a cluster probe and a per endpoint probe
* per endpoint probe was created even if endpoint was red in consul, preventing framework to schedule latency/durability checks
* per endpoint probe in addition of cluster probe make littles sense for latency check / durability check 