### PR TITLE
Implement Aerospike client reauth and LDAP-specific failure handling

### DIFF
--- a/configs/aerospike/aerospike_config.yaml
+++ b/configs/aerospike/aerospike_config.yaml
@@ -10,7 +10,7 @@ discovery:
     tags:
     - aerospike
 client_config:
-  ### AUTH ### 
+  ### AUTH ###
   # Enable authentication
   auth_enabled: true
   # Use external authentication (https://docs.aerospike.com/docs/guide/security/access-control.html#external-authentication-with-ldap)
@@ -24,7 +24,7 @@ client_config:
   # Meta key to find the tls-hostname to use for SSL cert validation
   tls_hostname_meta_key: "tls-hostname"
   # Skip ssl verification
-  tls_skip_verify: false 
+  tls_skip_verify: false
   ### Probe discovery configuration ###
   # The key prefix to discover Aerospike's namespaces through service discovery
   namespace_meta_key_prefix: "aerospike-monitoring-"
@@ -37,6 +37,7 @@ client_config:
   connection_queue_size: 2 # Avoid creating too many connections. We don't need many as we duplicate the clients many times
   opening_connection_threshold: 30
   min_connections_per_node: 2
+  reauth_interval: 2m # Close current connections and reauthenticate periodically
   exit_fast_on_exhausted_connection_pool: True
 checks_configs:
   latency_check:

--- a/pkg/aerospike/checks.go
+++ b/pkg/aerospike/checks.go
@@ -83,11 +83,20 @@ func hash(str string) string {
 	return hex.EncodeToString(hasher.Sum(nil))
 }
 
+func ensureAerospikeClientRefreshed(e *AerospikeEndpoint) error {
+	return e.EnsureFreshClient()
+}
+
 func LatencyCheck(p topology.ProbeableEndpoint) error {
 	e, ok := p.(*AerospikeEndpoint)
 	if !ok {
 		return fmt.Errorf("error: given endpoint is not an aerospike endpoint")
 	}
+
+	// Ignore the error to cause probing check failure; LDAP failures are logged anyway.
+	// We do *not* get the latency check fail alert, because when client is invalid,
+	// function fails before ObserveOpLatency. This differs from durability check behavior
+	ensureAerospikeClientRefreshed(e)
 
 	keyPrefix := e.ClusterConfig.genericConfig.LatencyKeyPrefix
 
@@ -186,6 +195,9 @@ func DurabilityPrepare(p topology.ProbeableEndpoint) error {
 	if !ok {
 		return fmt.Errorf("error: given endpoint is not an aerospike endpoint")
 	}
+	if err := ensureAerospikeClientRefreshed(e); err != nil {
+		return err
+	}
 
 	policy := as.NewWritePolicy(0, as.TTLDontExpire)                 // No expiration
 	policy.MaxRetries = 2                                            // We can retry for durability (0 is default Client value in v7)
@@ -249,6 +261,11 @@ func DurabilityCheck(p topology.ProbeableEndpoint) error {
 	if !ok {
 		return fmt.Errorf("error: given endpoint is not an aerospike endpoint")
 	}
+
+	// Ignore the error to cause probing check failure; LDAP failures are logged anyway
+	// We get data_unavailable when LDAP failures happen, as the gauges are set unconditionally
+	// at the bottom of this function
+	ensureAerospikeClientRefreshed(e)
 
 	policy := as.NewPolicy()
 	policy.MaxRetries = 2                                            // 2 is default Client value in v7

--- a/pkg/aerospike/config.go
+++ b/pkg/aerospike/config.go
@@ -56,6 +56,7 @@ type AerospikeEndpointConfig struct {
 	ConnectionQueueSize               int           `yaml:"connection_queue_size,omitempty"`
 	OpeningConnectionThreshold        int           `yaml:"opening_connection_threshold,omitempty"`
 	MinConnectionsPerNode             int           `yaml:"min_connections_per_node,omitempty"`
+	ReauthInterval                    time.Duration `yaml:"reauth_interval,omitempty"`
 	TendInterval                      time.Duration `yaml:"tend_interval,omitempty"`
 	TotalTimeout                      time.Duration `yaml:"total_timeout,omitempty"`
 	ExitFastOnExhaustedConnectionPool bool          `yaml:"exit_fast_on_exhausted_connection_pool,omitempty"`
@@ -77,6 +78,7 @@ var (
 		ConnectionQueueSize:               256,
 		OpeningConnectionThreshold:        0,
 		MinConnectionsPerNode:             0,
+		ReauthInterval:                    2 * time.Minute,
 		TendInterval:                      time.Second,
 		TotalTimeout:                      30 * time.Second,
 		ExitFastOnExhaustedConnectionPool: false,

--- a/pkg/aerospike/config_test.go
+++ b/pkg/aerospike/config_test.go
@@ -1,0 +1,40 @@
+package aerospike
+
+import (
+	"testing"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+func TestAerospikeEndpointConfigDefaults(t *testing.T) {
+	var cfg AerospikeEndpointConfig
+	if err := yaml.Unmarshal([]byte("{}"), &cfg); err != nil {
+		t.Fatalf("unexpected unmarshal error: %v", err)
+	}
+
+	if cfg.ReauthInterval != 2*time.Minute {
+		t.Fatalf("expected default reauth interval to be 2m, got %s", cfg.ReauthInterval)
+	}
+}
+
+func TestAerospikeEndpointShouldReauth(t *testing.T) {
+	now := time.Now()
+	endpoint := AerospikeEndpoint{
+		ClusterConfig: &AerospikeClientConfig{
+			genericConfig: &AerospikeEndpointConfig{
+				ReauthInterval: 2 * time.Minute,
+			},
+		},
+		lastReauthAttemptAt: now.Add(-3 * time.Minute),
+	}
+
+	if !endpoint.shouldReauth(now) {
+		t.Fatal("expected reauth to be required once the interval has elapsed")
+	}
+
+	endpoint.lastReauthAttemptAt = now.Add(-1 * time.Minute)
+	if endpoint.shouldReauth(now) {
+		t.Fatal("expected reauth to stay disabled before the interval elapses")
+	}
+}

--- a/pkg/aerospike/config_test.go
+++ b/pkg/aerospike/config_test.go
@@ -1,9 +1,12 @@
 package aerospike
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	as "github.com/aerospike/aerospike-client-go/v8"
+	ast "github.com/aerospike/aerospike-client-go/v8/types"
 	"gopkg.in/yaml.v2"
 )
 
@@ -36,5 +39,25 @@ func TestAerospikeEndpointShouldReauth(t *testing.T) {
 	endpoint.lastReauthAttemptAt = now.Add(-1 * time.Minute)
 	if endpoint.shouldReauth(now) {
 		t.Fatal("expected reauth to stay disabled before the interval elapses")
+	}
+}
+
+func TestLDAPSpecificResultCode(t *testing.T) {
+	err := fmt.Errorf("wrapped: %w", &as.AerospikeError{ResultCode: 93})
+
+	rc, rcName, ok := ldapSpecificResultCode(err)
+	if !ok {
+		t.Fatal("expected LDAP-specific result code to be detected")
+	}
+	if rc != 93 {
+		t.Fatalf("expected LDAP-specific result code 93, got %d", rc)
+	}
+	if rcName != "AS_SEC_ERR_LDAP_AUTHENTICATION" {
+		t.Fatalf("expected LDAP-specific result code name AS_SEC_ERR_LDAP_AUTHENTICATION, got %q", rcName)
+	}
+
+	err = fmt.Errorf("wrapped: %w", &as.AerospikeError{ResultCode: ast.NOT_AUTHENTICATED})
+	if _, _, ok := ldapSpecificResultCode(err); ok {
+		t.Fatal("expected NOT_AUTHENTICATED to stay outside the LDAP auth failure range")
 	}
 }

--- a/pkg/aerospike/endpoint.go
+++ b/pkg/aerospike/endpoint.go
@@ -2,6 +2,7 @@ package aerospike
 
 import (
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"time"
 
@@ -17,6 +18,11 @@ var clusterStats = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Name: ASSuffix + "_aerospike_client_cluster_stats",
 	Help: "Cluster aggregated metrics from the go aerospike client",
 }, []string{"cluster", "probe_endpoint", "namespace", "name"})
+
+var ldapSpecificFailuresTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+	Name: ASSuffix + "_ldap_specific_failures_total",
+	Help: "Total number of Aerospike LDAP-specific failures detected (when server auths with LDAP on our behalf)",
+}, []string{"cluster", "probe_endpoint", "namespace", "result_code", "result_code_name"})
 
 type AerospikeEndpoint struct {
 	Name                string
@@ -78,6 +84,48 @@ func (e *AerospikeEndpoint) refreshMetrics() {
 	e.setMetricFromASStats(cluster_stats, "tends-failed")
 }
 
+func ldapSpecificResultCode(err error) (int, string, bool) {
+	// Current LDAP-specific error codes, which are distinct from
+	// "invalid creds" errors:
+
+	/*
+		#define AS_SEC_ERR_LDAP_NOT_CONFIGURED  90 // LDAP features not configured
+		#define AS_SEC_ERR_LDAP_SETUP           91 // LDAP setup error
+		#define AS_SEC_ERR_LDAP_TLS_SETUP       92 // LDAP TLS setup error
+		#define AS_SEC_ERR_LDAP_AUTHENTICATION  93 // error authenticating LDAP user
+		#define AS_SEC_ERR_LDAP_QUERY           94 // error querying LDAP server
+	*/
+
+	// Values found at as/include/base/proto.h
+	// Presumably 95-99 are reserved for future LDAP-specific error codes
+
+	for err != nil {
+		var ae *as.AerospikeError
+		if errors.As(err, &ae) {
+			rc := int(ae.ResultCode)
+			if rc >= 90 && rc <= 99 {
+				switch rc {
+				case 90:
+					return rc, "AS_SEC_ERR_LDAP_NOT_CONFIGURED", true
+				case 91:
+					return rc, "AS_SEC_ERR_LDAP_SETUP", true
+				case 92:
+					return rc, "AS_SEC_ERR_LDAP_TLS_SETUP", true
+				case 93:
+					return rc, "AS_SEC_ERR_LDAP_AUTHENTICATION", true
+				case 94:
+					return rc, "AS_SEC_ERR_LDAP_QUERY", true
+				default:
+					// Reserved/not-yet-defined LDAP-specific error code
+					return rc, "", true
+				}
+			}
+		}
+		err = errors.Unwrap(err)
+	}
+	return 0, "", false
+}
+
 func (e *AerospikeEndpoint) connectClient() error {
 	e.lastReauthAttemptAt = time.Now()
 
@@ -109,6 +157,10 @@ func (e *AerospikeEndpoint) connectClient() error {
 
 	client, err := as.NewClientWithPolicyAndHost(clientPolicy, &e.ClusterConfig.host)
 	if err != nil {
+		if rc, rcName, ok := ldapSpecificResultCode(err); ok {
+			level.Error(e.Logger).Log("msg", fmt.Sprintf("LDAP-specific failure on %s", e.ClusterConfig.clusterName), "result_code", rc, "result_code_name", rcName)
+			ldapSpecificFailuresTotal.WithLabelValues(e.ClusterConfig.clusterName, e.GetName(), e.Namespace, fmt.Sprintf("%d", rc), rcName).Inc()
+		}
 		return err
 	}
 	e.Client = client

--- a/pkg/aerospike/endpoint.go
+++ b/pkg/aerospike/endpoint.go
@@ -3,6 +3,7 @@ package aerospike
 import (
 	"crypto/tls"
 	"fmt"
+	"time"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -18,13 +19,14 @@ var clusterStats = promauto.NewGaugeVec(prometheus.GaugeOpts{
 }, []string{"cluster", "probe_endpoint", "namespace", "name"})
 
 type AerospikeEndpoint struct {
-	Name          string
-	ClusterLevel  bool
-	ClusterName   string
-	Client        *as.Client
-	ClusterConfig *AerospikeClientConfig
-	Logger        log.Logger
-	Namespace     string
+	Name                string
+	ClusterLevel        bool
+	ClusterName         string
+	Client              *as.Client
+	ClusterConfig       *AerospikeClientConfig
+	Logger              log.Logger
+	Namespace           string
+	lastReauthAttemptAt time.Time
 }
 
 func (e *AerospikeEndpoint) GetHash() string {
@@ -53,6 +55,9 @@ func (e *AerospikeEndpoint) setMetricFromASStats(stats map[string]interface{}, k
 }
 
 func (e *AerospikeEndpoint) refreshMetrics() {
+	// Do note that these are client-side metrics, which means they are periodically lost as we now
+	// periodically re-create the client to detect auth issues.
+
 	stats, err := e.Client.Stats()
 	cluster_stats := stats["cluster-aggregated-stats"].(map[string]interface{})
 	if err != nil {
@@ -73,7 +78,9 @@ func (e *AerospikeEndpoint) refreshMetrics() {
 	e.setMetricFromASStats(cluster_stats, "tends-failed")
 }
 
-func (e *AerospikeEndpoint) Connect() error {
+func (e *AerospikeEndpoint) connectClient() error {
+	e.lastReauthAttemptAt = time.Now()
+
 	clientPolicy := as.NewClientPolicy()
 	clientPolicy.ConnectionQueueSize = e.ClusterConfig.genericConfig.ConnectionQueueSize
 	clientPolicy.OpeningConnectionThreshold = e.ClusterConfig.genericConfig.OpeningConnectionThreshold
@@ -105,6 +112,33 @@ func (e *AerospikeEndpoint) Connect() error {
 		return err
 	}
 	e.Client = client
+	return nil
+}
+
+func (e *AerospikeEndpoint) shouldReauth(now time.Time) bool {
+	reauthInterval := e.ClusterConfig.genericConfig.ReauthInterval
+	return reauthInterval > 0 && !e.lastReauthAttemptAt.IsZero() && now.Sub(e.lastReauthAttemptAt) >= reauthInterval
+}
+
+func (e *AerospikeEndpoint) reauth() error {
+	e.Close()
+	return e.connectClient()
+}
+
+func (e *AerospikeEndpoint) EnsureFreshClient() error {
+	if e.shouldReauth(time.Now()) {
+		level.Debug(e.Logger).Log("msg", "Reauthenticating Aerospike client")
+		if err := e.reauth(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (e *AerospikeEndpoint) Connect() error {
+	if err := e.connectClient(); err != nil {
+		return err
+	}
 	e.Refresh()
 	return nil
 }


### PR DESCRIPTION
This PR adds periodic Aerospike client reauthentication, and specifically improves visibility into LDAP-specific failures.
Previously, we wouldn't detect LDAP failures our users would face as sessions are kept alive for up to 10 days (by default on Aerospike).

**Changes:**

- Periodically close and recreate the Aerospike client to force reauth:
    - Added `client_config.reauth_interval` to Aerospike endpoint config (default: 2m)
    - Tracks the last reauth attempt, not just last successful auth time, to avoid retry floods on repeated failures
    - Note that this changes the behavior of `blackbox_prober_aerospike_client_cluster_stats` (as these metrics are client-side)
- Detect LDAP-specific Aerospike result codes in the `90..99` range
  - This corresponds to LDAP-specific errors, not "invalid credential" stuff
  - Translates known codes to names when available
  **- Added `blackbox_prober_aerospike_ldap_specific_failures_total` so that we can be paged as soon as possible** (we can `sum` the hypothetical alert per DC to avoid alert fatigue)



