### PR TITLE
aerospike: make client connection timeout configurable (default 5s)

### DIFF
--- a/pkg/aerospike/config.go
+++ b/pkg/aerospike/config.go
@@ -58,6 +58,7 @@ type AerospikeEndpointConfig struct {
 	MinConnectionsPerNode             int           `yaml:"min_connections_per_node,omitempty"`
 	TendInterval                      time.Duration `yaml:"tend_interval,omitempty"`
 	TotalTimeout                      time.Duration `yaml:"total_timeout,omitempty"`
+	ConnectionTimeout                 time.Duration `yaml:"connection_timeout,omitempty"`
 	ExitFastOnExhaustedConnectionPool bool          `yaml:"exit_fast_on_exhausted_connection_pool,omitempty"`
 }
 
@@ -79,6 +80,7 @@ var (
 		MinConnectionsPerNode:             0,
 		TendInterval:                      time.Second,
 		TotalTimeout:                      30 * time.Second,
+		ConnectionTimeout:                 5 * time.Second,
 		ExitFastOnExhaustedConnectionPool: false,
 	}
 )

--- a/pkg/aerospike/endpoint.go
+++ b/pkg/aerospike/endpoint.go
@@ -79,6 +79,11 @@ func (e *AerospikeEndpoint) Connect() error {
 	clientPolicy.OpeningConnectionThreshold = e.ClusterConfig.genericConfig.OpeningConnectionThreshold
 	clientPolicy.MinConnectionsPerNode = e.ClusterConfig.genericConfig.MinConnectionsPerNode
 	clientPolicy.TendInterval = e.ClusterConfig.genericConfig.TendInterval
+	// Timeout bounds connection establishment: the TCP dial and the initial socket
+	// deadline (incl. TLS handshake) of a freshly opened connection. The driver defaults
+	// it to 30s, so tends stall ~30s dialing each unreachable node during a roll-restart.
+	// (Steady-state reads/writes and LDAP login use their own per-command timeouts.)
+	clientPolicy.Timeout = e.ClusterConfig.genericConfig.ConnectionTimeout
 
 	if e.ClusterConfig.tlsEnabled {
 		// Setup TLS Config


### PR DESCRIPTION
The Aerospike client's dial/connection timeout (ClientPolicy.Timeout) was left at the driver default of 30s, so during a cluster roll-restart each tend blocked 30s per unreachable node ("Tending took 30s"), collapsing the effective tend cadence. Expose it as connection_timeout and default it to 5s.