### PR TITLE
Aerospike durability exit fast

### DIFF
--- a/pkg/aerospike/checks.go
+++ b/pkg/aerospike/checks.go
@@ -190,6 +190,8 @@ func DurabilityPrepare(p topology.ProbeableEndpoint) error {
 	policy := as.NewWritePolicy(0, as.TTLDontExpire)                 // No expiration
 	policy.MaxRetries = 2                                            // We can retry for durability (0 is default Client value in v7)
 	policy.TotalTimeout = e.ClusterConfig.genericConfig.TotalTimeout // 0 is default Client value in v7
+	// Do not wait until timeout if connections cannot be open
+	policy.ExitFastOnExhaustedConnectionPool = e.ClusterConfig.genericConfig.ExitFastOnExhaustedConnectionPool
 	keyRange := e.ClusterConfig.genericConfig.DurabilityKeyTotal
 	keyPrefix := e.ClusterConfig.genericConfig.DurabilityKeyPrefix
 	// allPushedFlag indicate if a probe have pushed all data once
@@ -254,6 +256,8 @@ func DurabilityCheck(p topology.ProbeableEndpoint) error {
 	policy.MaxRetries = 2                                            // 2 is default Client value in v7
 	policy.ReplicaPolicy = as.SEQUENCE                               // SEQUENCE is default Client value (alternate across master/replica in case of errors)
 	policy.TotalTimeout = e.ClusterConfig.genericConfig.TotalTimeout // 0 is default Client value in v7
+	// Do not wait until timeout if connections cannot be open
+	policy.ExitFastOnExhaustedConnectionPool = e.ClusterConfig.genericConfig.ExitFastOnExhaustedConnectionPool
 	keyRange := e.ClusterConfig.genericConfig.DurabilityKeyTotal
 	keyPrefix := e.ClusterConfig.genericConfig.DurabilityKeyPrefix
 

--- a/pkg/aerospike/config.go
+++ b/pkg/aerospike/config.go
@@ -58,6 +58,7 @@ type AerospikeEndpointConfig struct {
 	MinConnectionsPerNode             int           `yaml:"min_connections_per_node,omitempty"`
 	TendInterval                      time.Duration `yaml:"tend_interval,omitempty"`
 	TotalTimeout                      time.Duration `yaml:"total_timeout,omitempty"`
+	ConnectionTimeout                 time.Duration `yaml:"connection_timeout,omitempty"`
 	ExitFastOnExhaustedConnectionPool bool          `yaml:"exit_fast_on_exhausted_connection_pool,omitempty"`
 }
 
@@ -79,6 +80,7 @@ var (
 		MinConnectionsPerNode:             0,
 		TendInterval:                      time.Second,
 		TotalTimeout:                      30 * time.Second,
+		ConnectionTimeout:                 5 * time.Second,
 		ExitFastOnExhaustedConnectionPool: false,
 	}
 )

--- a/pkg/aerospike/endpoint.go
+++ b/pkg/aerospike/endpoint.go
@@ -79,6 +79,11 @@ func (e *AerospikeEndpoint) Connect() error {
 	clientPolicy.OpeningConnectionThreshold = e.ClusterConfig.genericConfig.OpeningConnectionThreshold
 	clientPolicy.MinConnectionsPerNode = e.ClusterConfig.genericConfig.MinConnectionsPerNode
 	clientPolicy.TendInterval = e.ClusterConfig.genericConfig.TendInterval
+	// Timeout bounds connection establishment: the TCP dial and the initial socket
+	// deadline (incl. TLS handshake) of a freshly opened connection. The driver defaults
+	// it to 30s, so tends stall ~30s dialing each unreachable node during a roll-restart.
+	// (Steady-state reads/writes and LDAP login use their own per-command timeouts.)
+	clientPolicy.Timeout = e.ClusterConfig.genericConfig.ConnectionTimeout
 
 	if e.ClusterConfig.tlsEnabled {
 		// Setup TLS Config


### PR DESCRIPTION
aerospike: honor exit_fast_on_exhausted_connection_pool in durability checks

DurabilityCheck and DurabilityPrepare ignored the configured
ExitFastOnExhaustedConnectionPool flag; only LatencyCheck applied it.

During connection-pool exhaustion (e.g. a cluster roll-restart) each Get/Put therefore
blocked up to TotalTimeout waiting for a connection instead of failing fast.

Since latency and durability share one worker goroutine, and Connect/
PrepareProbing run synchronously in the scheduler loop, this could wedge the
worker (starving the latency check that drives the availability SLO) for up to
DurabilityKeyTotal * TotalTimeout.

Apply the flag consistently across all check policies. DurabilityPrepare stays
correct under fail-fast: it is idempotent, guarded by the all_pushed_flag key,
and retried each discovery cycle, so a partial insertion is fully redone next
cycle and the check never reads a partial baseline.