### PR TITLE
aerospike: seed the client with all discovered cluster nodes

### DIFF
--- a/pkg/aerospike/config.go
+++ b/pkg/aerospike/config.go
@@ -22,8 +22,9 @@ type AerospikeClientConfig struct {
 	// tls
 	tlsEnabled  bool
 	tlsHostname string
-	// Contact point
-	host as.Host
+	// Contact points (seeds): all discovered nodes of the cluster, so the client
+	// can still bootstrap from a surviving node if some pods have changed IP.
+	hosts []*as.Host
 	// Config
 	genericConfig *AerospikeEndpointConfig
 

--- a/pkg/aerospike/discovery.go
+++ b/pkg/aerospike/discovery.go
@@ -50,12 +50,14 @@ func (conf *AerospikeProbeConfig) buildClusterClientConfig(logger log.Logger, en
 	}
 
 	nodeInfoCache := map[string]*common.ClusterNodeInfo{}
+	hosts := make([]*as.Host, 0, len(entries))
 	for _, entry := range entries {
 		nodeInfoCache[entry.Address] = &common.ClusterNodeInfo{
 			NodeName: entry.Address,
 			PodName:  entry.PodName,
 			NodeFqdn: entry.NodeFqdn,
 		}
+		hosts = append(hosts, &as.Host{Name: entry.Address, TLSName: tlsHostname, Port: entry.Port})
 	}
 
 	clusterConfig := AerospikeClientConfig{
@@ -69,8 +71,8 @@ func (conf *AerospikeProbeConfig) buildClusterClientConfig(logger log.Logger, en
 		tlsHostname: tlsHostname,
 		// conf
 		genericConfig: &conf.AerospikeEndpointConfig,
-		// Contact point
-		host: as.Host{Name: entries[0].Address, TLSName: tlsHostname, Port: entries[0].Port},
+		// Contact points (seeds)
+		hosts: hosts,
 		// node info cache
 		nodeInfoCache: nodeInfoCache,
 	}

--- a/pkg/aerospike/endpoint.go
+++ b/pkg/aerospike/endpoint.go
@@ -105,7 +105,7 @@ func (e *AerospikeEndpoint) Connect() error {
 		clientPolicy.Password = e.ClusterConfig.password
 	}
 
-	client, err := as.NewClientWithPolicyAndHost(clientPolicy, &e.ClusterConfig.host)
+	client, err := as.NewClientWithPolicyAndHost(clientPolicy, e.ClusterConfig.hosts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
buildClusterClientConfig passed only entries[0] as the single seed host. If that node's pod changed IP, the client had no other  seed to bootstrap from.

Usually it's not an issue since it's used at boostrap of the client ... but seed are also used in case of cluster empty or topology completely wrong if a rapid roll-restart occurs (in few seconds) and connection pool exhaustion prevented to refresh peers.

Pass every discovered node as a seed so the client can still reach the cluster as long as one node's IP is unchanged.

This change is not the cure of all connectivity issue of the probe but increase resiliency in case of berezina case.