### PR TITLE
aerospike: fine-tune parallelism of checks

### DIFF
--- a/pkg/aerospike/checks.go
+++ b/pkg/aerospike/checks.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
+	"runtime"
 	"time"
 
 	as "github.com/aerospike/aerospike-client-go/v8"
@@ -54,15 +55,22 @@ var durabilityCorruptedItems = promauto.NewGaugeVec(prometheus.GaugeOpts{
 	Help: "Total number of items found to be corrupted for durability",
 }, []string{"namespace", "cluster", "probe_endpoint"})
 
-// namespaceCheckParallelism keeps the total check fanout at or below the old rough maximum.
-// With independent scheduler checks, latency and durability may run at the same time; limiting
-// each check to ceil(namespaces/2) means both checks together run at most one namespace lane per
-// monitored namespace. DurabilityPrepare uses a lower limit to avoid startup write bursts.
+// namespaceCheckParallelism caps latency fanout to the Go scheduler's CPU budget, leaving one
+// P for runtime work, tend/refresh traffic, and other checks. In containers this assumes
+// GOMAXPROCS is set to the pod CPU limit (or derived by the runtime/tooling).
 func namespaceCheckParallelism(namespaceCount int) int {
 	if namespaceCount <= 1 {
 		return 1
 	}
-	return (namespaceCount + 1) / 2
+
+	cpuBudget := runtime.GOMAXPROCS(0) - 1
+	if cpuBudget < 1 {
+		cpuBudget = 1
+	}
+	if namespaceCount < cpuBudget {
+		return namespaceCount
+	}
+	return cpuBudget
 }
 
 // forEachNamespace runs fn for every monitored namespace of the endpoint, with a bounded number
@@ -303,7 +311,7 @@ func DurabilityCheck(p topology.ProbeableEndpoint) error {
 	if !ok {
 		return fmt.Errorf("error: given endpoint is not an aerospike endpoint")
 	}
-	return forEachNamespace(e, namespaceCheckParallelism(len(e.Namespaces)), func(namespace string) error {
+	return forEachNamespace(e, 1, func(namespace string) error {
 		return durabilityCheckNamespace(e, namespace)
 	})
 }
@@ -358,7 +366,7 @@ const (
 	authStatusAuthFail  = "auth_failure"
 	authStatusConnError = "connection_error"
 
-	maxAuthCheckParallelism = 8
+	maxAuthCheckParallelism = 2
 )
 
 func authCheckParallelism(targetCount int) int {

--- a/pkg/aerospike/checks_test.go
+++ b/pkg/aerospike/checks_test.go
@@ -3,6 +3,7 @@ package aerospike
 import (
 	"errors"
 	"fmt"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -121,6 +122,9 @@ func TestForEachNamespaceHonorsParallelism(t *testing.T) {
 }
 
 func TestNamespaceCheckParallelism(t *testing.T) {
+	previous := runtime.GOMAXPROCS(3)
+	defer runtime.GOMAXPROCS(previous)
+
 	for _, tc := range []struct {
 		name       string
 		namespaces int
@@ -128,7 +132,7 @@ func TestNamespaceCheckParallelism(t *testing.T) {
 	}{
 		{name: "none", namespaces: 0, want: 1},
 		{name: "one", namespaces: 1, want: 1},
-		{name: "two", namespaces: 2, want: 1},
+		{name: "two", namespaces: 2, want: 2},
 		{name: "three", namespaces: 3, want: 2},
 		{name: "four", namespaces: 4, want: 2},
 	} {
@@ -137,6 +141,15 @@ func TestNamespaceCheckParallelism(t *testing.T) {
 				t.Fatalf("expected parallelism %d, got %d", tc.want, got)
 			}
 		})
+	}
+}
+
+func TestNamespaceCheckParallelismSingleCPU(t *testing.T) {
+	previous := runtime.GOMAXPROCS(1)
+	defer runtime.GOMAXPROCS(previous)
+
+	if got := namespaceCheckParallelism(4); got != 1 {
+		t.Fatalf("expected parallelism 1 with one GOMAXPROCS, got %d", got)
 	}
 }
 
@@ -278,7 +291,8 @@ func TestAuthCheckParallelism(t *testing.T) {
 	}{
 		{name: "none", targets: 0, want: 1},
 		{name: "one", targets: 1, want: 1},
-		{name: "three", targets: 3, want: 3},
+		{name: "two", targets: 2, want: 2},
+		{name: "three", targets: 3, want: 2},
 		{name: "many", targets: maxAuthCheckParallelism + 3, want: maxAuthCheckParallelism},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/aerospike/endpoint.go
+++ b/pkg/aerospike/endpoint.go
@@ -80,10 +80,11 @@ func (e *AerospikeEndpoint) refreshMetrics() {
 func (e *AerospikeEndpoint) Connect() error {
 	clientPolicy := as.NewClientPolicy()
 
-	// Dynamically adjust the pool from the expected probe concurrency. Latency and durability can
-	// run independently, each with bounded namespace fanout; add headroom for refresh/tend traffic.
+	// Dynamically adjust the pool from the expected probe concurrency. Latency uses CPU-aware
+	// namespace fanout; durability is serial but can overlap with latency, so add one durability
+	// lane plus headroom for refresh/tend traffic. Auth checks bypass this pool.
 	namespaceParallelism := namespaceCheckParallelism(len(e.Namespaces))
-	expectedConcurrency := 2*namespaceParallelism + 1
+	expectedConcurrency := namespaceParallelism + 2
 	clientPolicy.MinConnectionsPerNode = 2 * expectedConcurrency
 	if clientPolicy.ConnectionQueueSize <= clientPolicy.MinConnectionsPerNode {
 		clientPolicy.ConnectionQueueSize = clientPolicy.MinConnectionsPerNode + 1

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -276,7 +276,20 @@ func (pw *ProberWorker) prepareProbing() error {
 
 func (pw *ProberWorker) runCheck(check Check) {
 	level.Debug(pw.logger).Log("msg", fmt.Sprintf("Performing check %s", check.Name))
-	if err := check.CheckFn(pw.endpoint); err != nil {
+	start := time.Now()
+	err := check.CheckFn(pw.endpoint)
+	duration := time.Since(start)
+	if check.Interval > 0 && duration > check.Interval {
+		level.Warn(pw.logger).Log(
+			"msg", "Check duration exceeded interval",
+			"check_name", check.Name,
+			"endpoint_name", pw.endpoint.GetName(),
+			"endpoint_hash", pw.endpoint.GetHash(),
+			"duration", duration.String(),
+			"interval", check.Interval.String(),
+		)
+	}
+	if err != nil {
 		CheckFailureTotal.WithLabelValues(check.Name, pw.endpoint.GetName(), check.Name).Inc()
 		level.Error(pw.logger).Log("msg", "Error while probing", "err", err)
 	} else {

--- a/pkg/scheduler/scheduler_test.go
+++ b/pkg/scheduler/scheduler_test.go
@@ -1,7 +1,9 @@
 package scheduler
 
 import (
+	"bytes"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -106,6 +108,39 @@ func TestWorkerStopIfNoChecks(t *testing.T) {
 		refreshInterval: 10 * time.Millisecond,
 	}
 	w.startProbing()
+}
+
+func TestRunCheckLogsWhenDurationExceedsInterval(t *testing.T) {
+	var buf bytes.Buffer
+	endpoint := &topology.DummyEndpoint{Name: "slow-endpoint", Hash: "slow-hash"}
+	w := ProberWorker{
+		logger:   log.NewLogfmtLogger(&buf),
+		endpoint: endpoint,
+	}
+	check := Check{
+		Name: "slow-check",
+		CheckFn: func(topology.ProbeableEndpoint) error {
+			time.Sleep(time.Millisecond)
+			return nil
+		},
+		Interval: time.Nanosecond,
+	}
+
+	w.runCheck(check)
+
+	logs := buf.String()
+	for _, want := range []string{
+		`msg="Check duration exceeded interval"`,
+		"check_name=slow-check",
+		"endpoint_name=slow-endpoint",
+		"endpoint_hash=slow-hash",
+		"duration=",
+		"interval=1ns",
+	} {
+		if !strings.Contains(logs, want) {
+			t.Fatalf("expected log to contain %q, got %q", want, logs)
+		}
+	}
 }
 
 // Checks are different between cluster endpoints and node endpoints


### PR DESCRIPTION
1. initial degree of parallelism was too high for latency check (up to 16 namespace latency check in parallel whereas probe has access to 6 cores only). now we limit degree of parallelism to GOMAXPROCS-1.

2. new auth_check is quite heavy on cpu due to hashing of password routine that is done for each login attempt. Degree of parallelism reduced to 2

3. There is a risk that some checks come late, added a log to detect such cases.