### PR TITLE
[Aerospike](fix) Add ability to setup a list of not ready namespaces

### DIFF
--- a/pkg/aerospike/discovery.go
+++ b/pkg/aerospike/discovery.go
@@ -3,6 +3,7 @@ package aerospike
 import (
 	"fmt"
 	"os"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -106,13 +107,22 @@ func (conf AerospikeProbeConfig) getNamespacesFromEntry(logger log.Logger, entry
 	return namespaces
 }
 
+func (conf *AerospikeProbeConfig) shouldSkipNamespace(namespace, cluster string) bool {
+	notReadyNamespaces, found := conf.DiscoveryConfig.NotReadyNamespaces[cluster]
+	return found && slices.Contains(notReadyNamespaces, namespace)
+}
+
 // generateEndpointFromEntry builds the single endpoint that covers a whole cluster.
 // TODO: we should use a consul dns seed
 func (conf *AerospikeProbeConfig) generateEndpointFromEntry(logger log.Logger, entry discovery.ServiceEntry, clusterConfig *AerospikeClientConfig) *AerospikeEndpoint {
 	namespaceSet := conf.getNamespacesFromEntry(logger, entry)
 	namespaces := make([]string, 0, len(namespaceSet))
 	for namespace := range namespaceSet {
-		namespaces = append(namespaces, namespace)
+		if conf.shouldSkipNamespace(namespace, clusterConfig.clusterName) {
+			level.Info(logger).Log("msg", fmt.Sprintf("Skipping namespace %s on cluster %s as it is not ready for monitoring.", namespace, clusterConfig.clusterName))
+		} else {
+			namespaces = append(namespaces, namespace)
+		}
 	}
 	// Keep sorted so GetHash is stable regardless of map iteration order.
 	sort.Strings(namespaces)

--- a/pkg/aerospike/discovery_test.go
+++ b/pkg/aerospike/discovery_test.go
@@ -139,3 +139,141 @@ func TestBuildTopologyCreatesSingleEndpointWithSortedNamespaces(t *testing.T) {
 		t.Fatalf("expected sorted namespaces %v, got %v", expectedNamespaces, aerospikeEndpoint.Namespaces)
 	}
 }
+
+func TestShouldSkipNamespace(t *testing.T) {
+	tests := []struct {
+		name               string
+		notReadyNamespaces map[string][]string
+		namespace          string
+		cluster            string
+		want               bool
+	}{
+		{
+			name:      "nil configuration",
+			namespace: "namespace-1",
+			cluster:   "cluster-1",
+		},
+		{
+			name:               "empty configuration",
+			notReadyNamespaces: map[string][]string{},
+			namespace:          "namespace-1",
+			cluster:            "cluster-1",
+		},
+		{
+			name: "cluster is not configured",
+			notReadyNamespaces: map[string][]string{
+				"cluster-2": {"namespace-1"},
+			},
+			namespace: "namespace-1",
+			cluster:   "cluster-1",
+		},
+		{
+			name: "cluster has no not-ready namespaces",
+			notReadyNamespaces: map[string][]string{
+				"cluster-1": {},
+			},
+			namespace: "namespace-1",
+			cluster:   "cluster-1",
+		},
+		{
+			name: "namespace is not configured for cluster",
+			notReadyNamespaces: map[string][]string{
+				"cluster-1": {"namespace-2"},
+			},
+			namespace: "namespace-1",
+			cluster:   "cluster-1",
+		},
+		{
+			name: "namespace is configured for cluster",
+			notReadyNamespaces: map[string][]string{
+				"cluster-1": {"namespace-1", "namespace-2"},
+			},
+			namespace: "namespace-1",
+			cluster:   "cluster-1",
+			want:      true,
+		},
+		{
+			name: "same namespace is only skipped on configured cluster",
+			notReadyNamespaces: map[string][]string{
+				"cluster-2": {"namespace-1"},
+			},
+			namespace: "namespace-1",
+			cluster:   "cluster-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := AerospikeProbeConfig{
+				DiscoveryConfig: discovery.GenericDiscoveryConfig{
+					NotReadyNamespaces: tt.notReadyNamespaces,
+				},
+			}
+
+			if got := config.shouldSkipNamespace(tt.namespace, tt.cluster); got != tt.want {
+				t.Errorf("shouldSkipNamespace(%q, %q) = %t, want %t", tt.namespace, tt.cluster, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateEndpointSkipsNotReadyNamespaces(t *testing.T) {
+	entry := discovery.ServiceEntry{
+		Address: "node-1",
+		Meta: map[string]string{
+			"aerospike-monitoring-namespace-1": "true",
+			"aerospike-monitoring-namespace-2": "true",
+		},
+	}
+
+	tests := []struct {
+		name               string
+		notReadyNamespaces map[string][]string
+		wantNamespaces     []string
+	}{
+		{
+			name:           "no skip configuration",
+			wantNamespaces: []string{"namespace-1", "namespace-2"},
+		},
+		{
+			name: "skip one namespace",
+			notReadyNamespaces: map[string][]string{
+				"cluster-1": {"namespace-1"},
+			},
+			wantNamespaces: []string{"namespace-2"},
+		},
+		{
+			name: "do not skip namespace configured for another cluster",
+			notReadyNamespaces: map[string][]string{
+				"cluster-2": {"namespace-1"},
+			},
+			wantNamespaces: []string{"namespace-1", "namespace-2"},
+		},
+		{
+			name: "skip all namespaces",
+			notReadyNamespaces: map[string][]string{
+				"cluster-1": {"namespace-1", "namespace-2"},
+			},
+			wantNamespaces: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := AerospikeProbeConfig{
+				DiscoveryConfig: discovery.GenericDiscoveryConfig{
+					NotReadyNamespaces: tt.notReadyNamespaces,
+				},
+				AerospikeEndpointConfig: AerospikeEndpointConfig{
+					NamespaceMetaKeyPrefix: "aerospike-monitoring-",
+				},
+			}
+			clusterConfig := &AerospikeClientConfig{clusterName: "cluster-1"}
+
+			endpoint := config.generateEndpointFromEntry(log.NewNopLogger(), entry, clusterConfig)
+			if !reflect.DeepEqual(endpoint.Namespaces, tt.wantNamespaces) {
+				t.Errorf("generated namespaces = %v, want %v", endpoint.Namespaces, tt.wantNamespaces)
+			}
+		})
+	}
+}

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -31,6 +31,8 @@ type ServiceEntry struct {
 type GenericDiscoveryConfig struct {
 	// Key for the cluster name
 	MetaClusterKey string `yaml:"meta_cluster_key,omitempty"`
+	// List of namespaces not ready for monitoring
+	NotReadyNamespaces map[string][]string `yaml:"not_ready_namespaces,omitempty"`
 	// Specific configuration consul
 	ConsulConfig ConsulConfig `yaml:"consul_sd_config,omitempty"`
 }


### PR DESCRIPTION
- Add the ability to skip some Aerospike namespaces if they are not ready yet for monitoring